### PR TITLE
Add health endpoint

### DIFF
--- a/squid/api.py
+++ b/squid/api.py
@@ -23,6 +23,11 @@ async def lifespan(_app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
 async def get_db():
     assert _db is not None, "DatabaseManager should be initialized at app startup"
     return _db


### PR DESCRIPTION
## Summary
- define a simple health endpoint at `/health`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_6879e785aaec8322be8fcd21bd00d730