### PR TITLE
Automate requirements sync from uv.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,33 +38,6 @@ jobs:
     - name: Install the project
       run: uv sync --all-extras --dev
 
-    - name: Check that requirements are up to date
-      # Basically, we generate the requirements files from the uv.lock file in CI
-      # and strip the first 2 lines (the uv export comment) before diffing them
-      run: |
-        tmpdir=$(mktemp -d)
-        uv export --output-file "$tmpdir/base.txt" --quiet
-        uv export --only-dev --output-file "$tmpdir/dev.txt" --quiet
-
-        # Normalize the first two lines (the uv export comment) before diffing
-        tail -n +3 "$tmpdir/base.txt" > "$tmpdir/base_stripped.txt"
-        tail -n +3 "$tmpdir/dev.txt" > "$tmpdir/dev_stripped.txt"
-        tail -n +3 requirements/base.txt > "$tmpdir/base_expected_stripped.txt"
-        tail -n +3 requirements/dev.txt > "$tmpdir/dev_expected_stripped.txt"
-
-        diff_output=0
-
-        diff -u "$tmpdir/base_stripped.txt" "$tmpdir/base_expected_stripped.txt" || diff_output=1
-        diff -u "$tmpdir/dev_stripped.txt" "$tmpdir/dev_expected_stripped.txt" || diff_output=1
-
-        if [ $diff_output -ne 0 ]; then
-          echo "requirements/*.txt files are not up to date with uv.lock."
-          echo "Run the following commands and commit the changes:"
-          echo "  uv export -o requirements/base.txt"
-          echo "  uv export --only-dev -o requirements/dev.txt"
-          exit 1
-        fi
-
     - name: Check all files have corresponding gitattributes
       run: |  # https://github.com/gitattributes/gitattributes
         missing_attributes=$(git ls-files | git check-attr -a --stdin | grep 'text: auto' || printf '\n')

--- a/.github/workflows/sync-requirements.yml
+++ b/.github/workflows/sync-requirements.yml
@@ -1,0 +1,44 @@
+name: Sync requirements from uv.lock
+
+permissions:
+  contents: write
+
+on:
+  push:
+    paths:
+      - uv.lock
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.14"
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Export requirements
+        run: |
+          uv export --output-file requirements/base.txt --quiet
+          uv export --only-dev --output-file requirements/dev.txt --quiet
+
+      - name: Commit updated requirements
+        run: |
+          if git diff --quiet -- requirements/base.txt requirements/dev.txt; then
+            echo "No requirement updates needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add requirements/base.txt requirements/dev.txt
+          git commit -m "Sync requirements from uv.lock"
+          git push


### PR DESCRIPTION
### Motivation
- Ensure `requirements/` files are kept in sync with `uv.lock` automatically to avoid CI failures and manual exports when dependencies change.

### Description
- Add a new GitHub Actions workflow `.github/workflows/sync-requirements.yml` that triggers on `uv.lock` changes and runs `uv export` to regenerate `requirements/base.txt` and `requirements/dev.txt`, then commits and pushes any updates.
- Grant the workflow `contents: write` permission and use `astral-sh/setup-uv@v5` to install `uv` and leverage cache via `cache-dependency-glob: "uv.lock"`.
- Remove the CI-only diff check from `.github/workflows/ci.yml` that previously compared `uv.lock` exports against `requirements/*.txt` since synchronization is now automated.

### Testing
- No automated tests were run as part of this change since it is workflow-only and affects CI automation rather than application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968a1008538832284085faa5c31c233)